### PR TITLE
Fix header search icon container

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -9,9 +9,9 @@ import Navigation from "../components/Navigation.astro";
 <header>
 <Avatar />
   <Navigation />
-  <dir class="search_icon">
-<SearchIcon />
-  </dir>
+  <div class="search_icon">
+    <SearchIcon />
+  </div>
 </header>
 
 


### PR DESCRIPTION
## Summary
- fix invalid `dir` tag in `Header.astro`

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852d075ec90832d8f84694d504ea31e